### PR TITLE
Consensus specs dev - pubkey-change implementation

### DIFF
--- a/consensus-specs-dev/Makefile
+++ b/consensus-specs-dev/Makefile
@@ -28,6 +28,7 @@ MARKDOWN_FILES = $(wildcard $(SPEC_DIR)/phase0/*.md) \
                  $(wildcard $(SPEC_DIR)/bellatrix/*.md) \
                  $(wildcard $(SPEC_DIR)/capella/*.md) $(wildcard $(SPEC_DIR)/capella/**/*.md) \
                  $(wildcard $(SPEC_DIR)/deneb/*.md) $(wildcard $(SPEC_DIR)/deneb/**/*.md) \
+				 $(wildcard $(SPEC_DIR)/revoke/*.md) $(wildcard $(SPEC_DIR)/revoke/**/*.md) \
                  $(wildcard $(SPEC_DIR)/_features/custody/*.md) \
                  $(wildcard $(SPEC_DIR)/_features/das/*.md) \
                  $(wildcard $(SPEC_DIR)/_features/sharding/*.md) \
@@ -68,6 +69,7 @@ partial_clean:
 	rm -rf $(ETH2SPEC_MODULE_DIR)/bellatrix
 	rm -rf $(ETH2SPEC_MODULE_DIR)/capella
 	rm -rf $(ETH2SPEC_MODULE_DIR)/deneb
+	rm -rf $(ETH2SPEC_MODULE_DIR)/revoke	
 	rm -rf $(COV_HTML_OUT_DIR)
 	rm -rf $(TEST_REPORT_DIR)
 	rm -rf eth2spec.egg-info dist build
@@ -142,7 +144,7 @@ codespell:
 lint: pyspec
 	. venv/bin/activate; cd $(PY_SPEC_DIR); \
 	flake8  --config $(LINTER_CONFIG_FILE) ./eth2spec \
-	&& pylint --rcfile $(LINTER_CONFIG_FILE) ./eth2spec/phase0 ./eth2spec/altair ./eth2spec/bellatrix ./eth2spec/capella ./eth2spec/deneb \
+	&& pylint --rcfile $(LINTER_CONFIG_FILE) ./eth2spec/phase0 ./eth2spec/altair ./eth2spec/bellatrix ./eth2spec/capella ./eth2spec/deneb ./eth2spec/revoke \
 	&& mypy --config-file $(LINTER_CONFIG_FILE) -p eth2spec.phase0 -p eth2spec.altair -p eth2spec.bellatrix -p eth2spec.capella -p eth2spec.deneb
 
 lint_generators: pyspec

--- a/consensus-specs-dev/setup.py
+++ b/consensus-specs-dev/setup.py
@@ -47,6 +47,7 @@ ALTAIR = 'altair'
 BELLATRIX = 'bellatrix'
 CAPELLA = 'capella'
 DENEB = 'deneb'
+REVOKE = 'revoke'
 
 
 # The helper functions that are used when defining constants
@@ -643,6 +644,17 @@ class DenebSpecBuilder(CapellaSpecBuilder):
 from eth2spec.capella import {preset_name} as capella
 '''
 
+#
+# RevokeSpecBuilder
+#
+class RevokeSpecBuilder(CapellaSpecBuilder):
+    fork: str = REVOKE
+
+    @classmethod
+    def imports(cls, preset_name: str):
+        return super().imports(preset_name) + f'''
+from eth2spec.capella import {preset_name} as capella
+'''
 
     @classmethod
     def preparations(cls):
@@ -661,15 +673,15 @@ def retrieve_blobs_sidecar(slot: Slot, beacon_block_root: Root) -> PyUnion[Blobs
     def hardcoded_custom_type_dep_constants(cls, spec_object) -> str:
         constants = {
             'BYTES_PER_FIELD_ELEMENT': spec_object.constant_vars['BYTES_PER_FIELD_ELEMENT'].value,
-            'FIELD_ELEMENTS_PER_BLOB': spec_object.preset_vars['FIELD_ELEMENTS_PER_BLOB'].value,
-            'MAX_BLOBS_PER_BLOCK': spec_object.preset_vars['MAX_BLOBS_PER_BLOCK'].value,
+            #'FIELD_ELEMENTS_PER_BLOB': spec_object.preset_vars['FIELD_ELEMENTS_PER_BLOB'].value,
+            #'MAX_BLOBS_PER_BLOCK': spec_object.preset_vars['MAX_BLOBS_PER_BLOCK'].value,
         }
         return {**super().hardcoded_custom_type_dep_constants(spec_object), **constants}
 
 
 spec_builders = {
     builder.fork: builder
-    for builder in (Phase0SpecBuilder, AltairSpecBuilder, BellatrixSpecBuilder, CapellaSpecBuilder, DenebSpecBuilder)
+    for builder in (Phase0SpecBuilder, AltairSpecBuilder, BellatrixSpecBuilder, CapellaSpecBuilder, DenebSpecBuilder, RevokeSpecBuilder)
 }
 
 
@@ -968,14 +980,14 @@ class PySpecCommand(Command):
         if len(self.md_doc_paths) == 0:
             print("no paths were specified, using default markdown file paths for pyspec"
                   " build (spec fork: %s)" % self.spec_fork)
-            if self.spec_fork in (PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB):
+            if self.spec_fork in (PHASE0, ALTAIR, BELLATRIX, CAPELLA, DENEB, REVOKE):
                 self.md_doc_paths = """
                     specs/phase0/beacon-chain.md
                     specs/phase0/fork-choice.md
                     specs/phase0/validator.md
                     specs/phase0/weak-subjectivity.md
                 """
-            if self.spec_fork in (ALTAIR, BELLATRIX, CAPELLA, DENEB):
+            if self.spec_fork in (ALTAIR, BELLATRIX, CAPELLA, DENEB, REVOKE):
                 self.md_doc_paths += """
                     specs/altair/light-client/full-node.md
                     specs/altair/light-client/light-client.md
@@ -987,7 +999,7 @@ class PySpecCommand(Command):
                     specs/altair/validator.md
                     specs/altair/p2p-interface.md
                 """
-            if self.spec_fork in (BELLATRIX, CAPELLA, DENEB):
+            if self.spec_fork in (BELLATRIX, CAPELLA, DENEB, REVOKE):
                 self.md_doc_paths += """
                     specs/bellatrix/beacon-chain.md
                     specs/bellatrix/fork.md
@@ -996,7 +1008,7 @@ class PySpecCommand(Command):
                     specs/bellatrix/p2p-interface.md
                     sync/optimistic.md
                 """
-            if self.spec_fork in (CAPELLA, DENEB):
+            if self.spec_fork in (CAPELLA, DENEB, REVOKE):
                 self.md_doc_paths += """
                     specs/capella/light-client/fork.md
                     specs/capella/light-client/full-node.md
@@ -1021,6 +1033,14 @@ class PySpecCommand(Command):
                     specs/deneb/p2p-interface.md
                     specs/deneb/validator.md
                 """
+            if self.spec_fork == REVOKE:
+                self.md_doc_paths += """
+                    specs/deneb/beacon-chain.md
+                    specs/deneb/fork.md
+                    specs/deneb/fork-choice.md
+                    specs/deneb/p2p-interface.md
+                    specs/deneb/validator.md
+                """                
             if len(self.md_doc_paths) == 0:
                 raise Exception('no markdown files specified, and spec fork "%s" is unknown', self.spec_fork)
 

--- a/consensus-specs-dev/specs/phase0/beacon-chain.md
+++ b/consensus-specs-dev/specs/phase0/beacon-chain.md
@@ -349,6 +349,7 @@ class Checkpoint(Container):
     root: Root
 ```
 
+### Extended Containers - Validators only
 #### `Validator`
 
 ```python
@@ -362,6 +363,9 @@ class Validator(Container):
     activation_epoch: Epoch
     exit_epoch: Epoch
     withdrawable_epoch: Epoch  # When validator can withdraw funds
+    new_pubkey: BLSPubkey # New in Revoke 
+    pubkey_change_epoch: Epoch # New in Revoke
+    prev_pubkeys: List[BLSPubkey, MAX_VALIDATOR_PUBKEY_CHANGES] # New in Revoke
 ```
 
 #### `AttestationData`
@@ -1253,6 +1257,7 @@ def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, valida
 ```
 
 ```python
+# REVOKETODO: What if pubkey changing? Check with mentor
 def verify_block_signature(state: BeaconState, signed_block: SignedBeaconBlock) -> bool:
     proposer = state.validators[signed_block.message.proposer_index]
     signing_root = compute_signing_root(signed_block.message, get_domain(state, DOMAIN_BEACON_PROPOSER))
@@ -1724,6 +1729,7 @@ def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
     # Verify RANDAO reveal
     proposer = state.validators[get_beacon_proposer_index(state)]
     signing_root = compute_signing_root(epoch, get_domain(state, DOMAIN_RANDAO))
+    # REVOKETODO: What if pubkey changing? Check with mentor
     assert bls.Verify(proposer.pubkey, signing_root, body.randao_reveal)
     # Mix in RANDAO reveal
     mix = xor(get_randao_mix(state, epoch), hash(body.randao_reveal))
@@ -1832,7 +1838,7 @@ def process_attestation(state: BeaconState, attestation: Attestation) -> None:
     assert is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation))
 ```
 
-##### Deposits
+##### Modified Deposits
 
 ```python
 def get_validator_from_deposit(deposit: Deposit) -> Validator:
@@ -1846,7 +1852,9 @@ def get_validator_from_deposit(deposit: Deposit) -> Validator:
         activation_epoch=FAR_FUTURE_EPOCH,
         exit_epoch=FAR_FUTURE_EPOCH,
         withdrawable_epoch=FAR_FUTURE_EPOCH,
+        pubkey_change_epoch=FAR_FUTURE_EPOCH, # New in Revoke
         effective_balance=effective_balance,
+        new_pubkey=deposit.data.pubkey # New in Revoke
     )
 ```
 
@@ -1867,6 +1875,8 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
     pubkey = deposit.data.pubkey
     amount = deposit.data.amount
     validator_pubkeys = [v.pubkey for v in state.validators]
+    #TODOREVOKE: Might want to disallow if new pubkey pending?
+    #Otherwise could end up with two validators with the same pubkey.
     if pubkey not in validator_pubkeys:
         # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
         deposit_message = DepositMessage(

--- a/consensus-specs-dev/specs/revoke/beacon-chain.md
+++ b/consensus-specs-dev/specs/revoke/beacon-chain.md
@@ -1,0 +1,540 @@
+# Capella -- The Beacon Chain
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Custom types](#custom-types)
+  - [Domain types](#domain-types)
+- [Preset](#preset)
+  - [Max operations per block](#max-operations-per-block)
+  - [Execution](#execution)
+  - [Withdrawals processing](#withdrawals-processing)
+- [Containers](#containers)
+  - [New containers](#new-containers)
+    - [`Withdrawal`](#withdrawal)
+    - [`BLSToExecutionChange`](#blstoexecutionchange)
+    - [`SignedBLSToExecutionChange`](#signedblstoexecutionchange)
+    - [`HistoricalSummary`](#historicalsummary)
+  - [Extended Containers](#extended-containers)
+    - [`ExecutionPayload`](#executionpayload)
+    - [`ExecutionPayloadHeader`](#executionpayloadheader)
+    - [`BeaconBlockBody`](#beaconblockbody)
+    - [`BeaconState`](#beaconstate)
+- [Helpers](#helpers)
+  - [Predicates](#predicates)
+    - [`has_eth1_withdrawal_credential`](#has_eth1_withdrawal_credential)
+    - [`is_fully_withdrawable_validator`](#is_fully_withdrawable_validator)
+    - [`is_partially_withdrawable_validator`](#is_partially_withdrawable_validator)
+- [Beacon chain state transition function](#beacon-chain-state-transition-function)
+  - [Epoch processing](#epoch-processing)
+    - [Historical summaries updates](#historical-summaries-updates)
+  - [Block processing](#block-processing)
+    - [New `get_expected_withdrawals`](#new-get_expected_withdrawals)
+    - [New `process_withdrawals`](#new-process_withdrawals)
+    - [Modified `process_execution_payload`](#modified-process_execution_payload)
+    - [Modified `process_operations`](#modified-process_operations)
+    - [New `process_bls_to_execution_change`](#new-process_bls_to_execution_change)
+- [Testing](#testing)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+Capella is a consensus-layer upgrade containing a number of features related
+to validator withdrawals. Including:
+* Automatic withdrawals of `withdrawable` validators.
+* Partial withdrawals sweep for validators with 0x01 withdrawal
+  credentials and balances in excess of `MAX_EFFECTIVE_BALANCE`.
+* Operation to change from `BLS_WITHDRAWAL_PREFIX` to
+  `ETH1_ADDRESS_WITHDRAWAL_PREFIX` versioned withdrawal credentials to enable withdrawals for a validator.
+
+Another new feature is the new independent state and block historical accumulators
+that replace the original singular historical roots. With these accumulators, it becomes possible to validate
+the entire block history that led up to that particular state without any additional information
+beyond the state and the blocks.
+
+## Custom types
+
+We define the following Python custom types for type hinting and readability:
+
+| Name | SSZ equivalent | Description |
+| - | - | - |
+| `WithdrawalIndex` | `uint64` | an index of a `Withdrawal` |
+
+### Domain types
+
+| Name | Value |
+| - | - |
+| `DOMAIN_BLS_TO_EXECUTION_CHANGE` | `DomainType('0x0A000000')` |
+
+## Preset
+
+### Max operations per block
+
+| Name | Value |
+| - | - |
+| `MAX_BLS_TO_EXECUTION_CHANGES` | `2**4` (= 16) |
+
+### Execution
+
+| Name | Value | Description |
+| - | - | - |
+| `MAX_WITHDRAWALS_PER_PAYLOAD` | `uint64(2**4)` (= 16) | Maximum amount of withdrawals allowed in each payload |
+
+### Withdrawals processing
+
+| Name | Value |
+| - | - |
+| `MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP` | `16384` (= 2**14 ) |
+
+## Containers
+
+### New containers
+
+#### `Withdrawal`
+
+```python
+class Withdrawal(Container):
+    index: WithdrawalIndex
+    validator_index: ValidatorIndex
+    address: ExecutionAddress
+    amount: Gwei
+```
+
+#### `BLSToExecutionChange`
+
+```python
+class BLSToExecutionChange(Container):
+    validator_index: ValidatorIndex
+    from_bls_pubkey: BLSPubkey
+    to_execution_address: ExecutionAddress
+```
+
+#### `SignedBLSToExecutionChange`
+
+```python
+class SignedBLSToExecutionChange(Container):
+    message: BLSToExecutionChange
+    signature: BLSSignature
+```
+
+#### `HistoricalSummary`
+
+```python
+class HistoricalSummary(Container):
+    """
+    `HistoricalSummary` matches the components of the phase0 `HistoricalBatch`
+    making the two hash_tree_root-compatible.
+    """
+    block_summary_root: Root
+    state_summary_root: Root
+```
+
+### Extended Containers
+
+#### `ExecutionPayload`
+
+```python
+class ExecutionPayload(Container):
+    # Execution block header fields
+    parent_hash: Hash32
+    fee_recipient: ExecutionAddress  # 'beneficiary' in the yellow paper
+    state_root: Bytes32
+    receipts_root: Bytes32
+    logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32  # 'difficulty' in the yellow paper
+    block_number: uint64  # 'number' in the yellow paper
+    gas_limit: uint64
+    gas_used: uint64
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas: uint256
+    # Extra payload fields
+    block_hash: Hash32  # Hash of execution block
+    transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+    withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]  # [New in Capella]
+```
+
+#### `ExecutionPayloadHeader`
+
+```python
+class ExecutionPayloadHeader(Container):
+    # Execution block header fields
+    parent_hash: Hash32
+    fee_recipient: ExecutionAddress
+    state_root: Bytes32
+    receipts_root: Bytes32
+    logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32
+    block_number: uint64
+    gas_limit: uint64
+    gas_used: uint64
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas: uint256
+    # Extra payload fields
+    block_hash: Hash32  # Hash of execution block
+    transactions_root: Root
+    withdrawals_root: Root  # [New in Capella]
+```
+
+#### `BeaconBlockBody`
+
+```python
+class BeaconBlockBody(Container):
+    randao_reveal: BLSSignature
+    eth1_data: Eth1Data  # Eth1 data vote
+    graffiti: Bytes32  # Arbitrary data
+    # Operations
+    proposer_slashings: List[ProposerSlashing, MAX_PROPOSER_SLASHINGS]
+    attester_slashings: List[AttesterSlashing, MAX_ATTESTER_SLASHINGS]
+    attestations: List[Attestation, MAX_ATTESTATIONS]
+    deposits: List[Deposit, MAX_DEPOSITS]
+    voluntary_exits: List[SignedVoluntaryExit, MAX_VOLUNTARY_EXITS]
+    sync_aggregate: SyncAggregate
+    # Execution
+    execution_payload: ExecutionPayload
+    # Capella operations
+    bls_to_execution_changes: List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]  # [New in Capella]
+```
+
+#### `BeaconState`
+
+```python
+class BeaconState(Container):
+    # Versioning
+    genesis_time: uint64
+    genesis_validators_root: Root
+    slot: Slot
+    fork: Fork
+    # History
+    latest_block_header: BeaconBlockHeader
+    block_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+    state_roots: Vector[Root, SLOTS_PER_HISTORICAL_ROOT]
+    historical_roots: List[Root, HISTORICAL_ROOTS_LIMIT]  # Frozen in Capella, replaced by historical_summaries
+    # Eth1
+    eth1_data: Eth1Data
+    eth1_data_votes: List[Eth1Data, EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH]
+    eth1_deposit_index: uint64
+    # Registry
+    validators: List[Validator, VALIDATOR_REGISTRY_LIMIT]
+    balances: List[Gwei, VALIDATOR_REGISTRY_LIMIT]
+    # Randomness
+    randao_mixes: Vector[Bytes32, EPOCHS_PER_HISTORICAL_VECTOR]
+    # Slashings
+    slashings: Vector[Gwei, EPOCHS_PER_SLASHINGS_VECTOR]  # Per-epoch sums of slashed effective balances
+    # Participation
+    previous_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+    current_epoch_participation: List[ParticipationFlags, VALIDATOR_REGISTRY_LIMIT]
+    # Finality
+    justification_bits: Bitvector[JUSTIFICATION_BITS_LENGTH]  # Bit set for every recent justified epoch
+    previous_justified_checkpoint: Checkpoint
+    current_justified_checkpoint: Checkpoint
+    finalized_checkpoint: Checkpoint
+    # Inactivity
+    inactivity_scores: List[uint64, VALIDATOR_REGISTRY_LIMIT]
+    # Sync
+    current_sync_committee: SyncCommittee
+    next_sync_committee: SyncCommittee
+    # Execution
+    latest_execution_payload_header: ExecutionPayloadHeader  # [Modified in Capella]
+    # Withdrawals
+    next_withdrawal_index: WithdrawalIndex  # [New in Capella]
+    next_withdrawal_validator_index: ValidatorIndex  # [New in Capella]
+    # Deep history valid from Capella onwards
+    historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]  # [New in Capella]
+```
+
+## Helpers
+
+### Predicates
+
+#### `has_eth1_withdrawal_credential`
+
+```python
+def has_eth1_withdrawal_credential(validator: Validator) -> bool:
+    """
+    Check if ``validator`` has an 0x01 prefixed "eth1" withdrawal credential.
+    """
+    return validator.withdrawal_credentials[:1] == ETH1_ADDRESS_WITHDRAWAL_PREFIX
+```
+
+#### `is_fully_withdrawable_validator`
+
+```python
+def is_fully_withdrawable_validator(validator: Validator, balance: Gwei, epoch: Epoch) -> bool:
+    """
+    Check if ``validator`` is fully withdrawable.
+    """
+    return (
+        has_eth1_withdrawal_credential(validator)
+        and validator.withdrawable_epoch <= epoch
+        and balance > 0
+    )
+```
+
+#### `is_partially_withdrawable_validator`
+
+```python
+def is_partially_withdrawable_validator(validator: Validator, balance: Gwei) -> bool:
+    """
+    Check if ``validator`` is partially withdrawable.
+    """
+    has_max_effective_balance = validator.effective_balance == MAX_EFFECTIVE_BALANCE
+    has_excess_balance = balance > MAX_EFFECTIVE_BALANCE
+    return has_eth1_withdrawal_credential(validator) and has_max_effective_balance and has_excess_balance
+```
+
+## Beacon chain state transition function
+
+### Epoch processing
+
+*Note*: The function `process_historical_summaries_update` replaces `process_historical_roots_update` in Bellatrix.
+
+```python
+def process_epoch(state: BeaconState) -> None:
+    process_justification_and_finalization(state)
+    process_inactivity_updates(state)
+    process_rewards_and_penalties(state)
+    process_registry_updates(state)
+    process_slashings(state)
+    process_eth1_data_reset(state)
+    process_effective_balance_updates(state)
+    process_slashings_reset(state)
+    process_randao_mixes_reset(state)
+    process_historical_summaries_update(state)  # [Modified in Capella]
+    process_participation_flag_updates(state)
+    process_sync_committee_updates(state)
+```
+
+#### Historical summaries updates
+
+```python
+def process_historical_summaries_update(state: BeaconState) -> None:
+    # Set historical block root accumulator.
+    next_epoch = Epoch(get_current_epoch(state) + 1)
+    if next_epoch % (SLOTS_PER_HISTORICAL_ROOT // SLOTS_PER_EPOCH) == 0:
+        historical_summary = HistoricalSummary(
+            block_summary_root=hash_tree_root(state.block_roots),
+            state_summary_root=hash_tree_root(state.state_roots),
+        )
+        state.historical_summaries.append(historical_summary)
+```
+
+### Block processing
+
+```python
+def process_block(state: BeaconState, block: BeaconBlock) -> None:
+    process_block_header(state, block)
+    if is_execution_enabled(state, block.body):
+        process_withdrawals(state, block.body.execution_payload)  # [New in Capella]
+        process_execution_payload(state, block.body.execution_payload, EXECUTION_ENGINE)  # [Modified in Capella]
+    process_randao(state, block.body)
+    process_eth1_data(state, block.body)
+    process_operations(state, block.body)  # [Modified in Capella]
+    process_sync_aggregate(state, block.body.sync_aggregate)
+```
+
+#### New `get_expected_withdrawals`
+
+```python
+def get_expected_withdrawals(state: BeaconState) -> Sequence[Withdrawal]:
+    epoch = get_current_epoch(state)
+    withdrawal_index = state.next_withdrawal_index
+    validator_index = state.next_withdrawal_validator_index
+    withdrawals: List[Withdrawal] = []
+    bound = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
+    for _ in range(bound):
+        validator = state.validators[validator_index]
+        balance = state.balances[validator_index]
+        if is_fully_withdrawable_validator(validator, balance, epoch):
+            withdrawals.append(Withdrawal(
+                index=withdrawal_index,
+                validator_index=validator_index,
+                address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                amount=balance,
+            ))
+            withdrawal_index += WithdrawalIndex(1)
+        elif is_partially_withdrawable_validator(validator, balance):
+            withdrawals.append(Withdrawal(
+                index=withdrawal_index,
+                validator_index=validator_index,
+                address=ExecutionAddress(validator.withdrawal_credentials[12:]),
+                amount=balance - MAX_EFFECTIVE_BALANCE,
+            ))
+            withdrawal_index += WithdrawalIndex(1)
+        if len(withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
+            break
+        validator_index = ValidatorIndex((validator_index + 1) % len(state.validators))
+    return withdrawals
+```
+
+#### New `process_withdrawals`
+
+```python
+def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
+    expected_withdrawals = get_expected_withdrawals(state)
+    assert len(payload.withdrawals) == len(expected_withdrawals)
+
+    for expected_withdrawal, withdrawal in zip(expected_withdrawals, payload.withdrawals):
+        assert withdrawal == expected_withdrawal
+        decrease_balance(state, withdrawal.validator_index, withdrawal.amount)
+
+    # Update the next withdrawal index if this block contained withdrawals
+    if len(expected_withdrawals) != 0:
+        latest_withdrawal = expected_withdrawals[-1]
+        state.next_withdrawal_index = WithdrawalIndex(latest_withdrawal.index + 1)
+
+    # Update the next validator index to start the next withdrawal sweep
+    if len(expected_withdrawals) == MAX_WITHDRAWALS_PER_PAYLOAD:
+        # Next sweep starts after the latest withdrawal's validator index
+        next_validator_index = ValidatorIndex((expected_withdrawals[-1].validator_index + 1) % len(state.validators))
+        state.next_withdrawal_validator_index = next_validator_index
+    else:
+        # Advance sweep by the max length of the sweep if there was not a full set of withdrawals
+        next_index = state.next_withdrawal_validator_index + MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP
+        next_validator_index = ValidatorIndex(next_index % len(state.validators))
+        state.next_withdrawal_validator_index = next_validator_index
+```
+
+#### Modified `process_execution_payload`
+
+*Note*: The function `process_execution_payload` is modified to use the new `ExecutionPayloadHeader` type.
+
+```python
+def process_execution_payload(state: BeaconState, payload: ExecutionPayload, execution_engine: ExecutionEngine) -> None:
+    # Verify consistency of the parent hash with respect to the previous execution payload header
+    if is_merge_transition_complete(state):
+        assert payload.parent_hash == state.latest_execution_payload_header.block_hash
+    # Verify prev_randao
+    assert payload.prev_randao == get_randao_mix(state, get_current_epoch(state))
+    # Verify timestamp
+    assert payload.timestamp == compute_timestamp_at_slot(state, state.slot)
+    # Verify the execution payload is valid
+    assert execution_engine.notify_new_payload(payload)
+    # Cache execution payload header
+    state.latest_execution_payload_header = ExecutionPayloadHeader(
+        parent_hash=payload.parent_hash,
+        fee_recipient=payload.fee_recipient,
+        state_root=payload.state_root,
+        receipts_root=payload.receipts_root,
+        logs_bloom=payload.logs_bloom,
+        prev_randao=payload.prev_randao,
+        block_number=payload.block_number,
+        gas_limit=payload.gas_limit,
+        gas_used=payload.gas_used,
+        timestamp=payload.timestamp,
+        extra_data=payload.extra_data,
+        base_fee_per_gas=payload.base_fee_per_gas,
+        block_hash=payload.block_hash,
+        transactions_root=hash_tree_root(payload.transactions),
+        withdrawals_root=hash_tree_root(payload.withdrawals),  # [New in Capella]
+    )
+```
+
+#### Modified `process_operations`
+
+*Note*: The function `process_operations` is modified to process `BLSToExecutionChange` operations included in the block.
+
+```python
+def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
+    # Verify that outstanding deposits are processed up to the maximum number of deposits
+    assert len(body.deposits) == min(MAX_DEPOSITS, state.eth1_data.deposit_count - state.eth1_deposit_index)
+
+    def for_ops(operations: Sequence[Any], fn: Callable[[BeaconState, Any], None]) -> None:
+        for operation in operations:
+            fn(state, operation)
+
+    for_ops(body.proposer_slashings, process_proposer_slashing)
+    for_ops(body.attester_slashings, process_attester_slashing)
+    for_ops(body.attestations, process_attestation)
+    for_ops(body.deposits, process_deposit)
+    for_ops(body.voluntary_exits, process_voluntary_exit)
+    for_ops(body.bls_to_execution_changes, process_bls_to_execution_change)  # [New in Capella]
+```
+
+#### New `process_bls_to_execution_change`
+
+```python
+def process_bls_to_execution_change(state: BeaconState,
+                                    signed_address_change: SignedBLSToExecutionChange) -> None:
+    address_change = signed_address_change.message
+
+    assert address_change.validator_index < len(state.validators)
+
+    validator = state.validators[address_change.validator_index]
+
+    assert validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX
+    assert validator.withdrawal_credentials[1:] == hash(address_change.from_bls_pubkey)[1:]
+
+    # Fork-agnostic domain since address changes are valid across forks
+    domain = compute_domain(DOMAIN_BLS_TO_EXECUTION_CHANGE, genesis_validators_root=state.genesis_validators_root)
+    signing_root = compute_signing_root(address_change, domain)
+    assert bls.Verify(address_change.from_bls_pubkey, signing_root, signed_address_change.signature)
+
+    validator.withdrawal_credentials = (
+        ETH1_ADDRESS_WITHDRAWAL_PREFIX
+        + b'\x00' * 11
+        + address_change.to_execution_address
+    )
+```
+
+## Testing
+
+*Note*: The function `initialize_beacon_state_from_eth1` is modified for pure Capella testing only.
+Modifications include:
+1. Use `CAPELLA_FORK_VERSION` as the previous and current fork version.
+2. Utilize the Capella `BeaconBlockBody` when constructing the initial `latest_block_header`.
+
+```python
+def initialize_beacon_state_from_eth1(eth1_block_hash: Hash32,
+                                      eth1_timestamp: uint64,
+                                      deposits: Sequence[Deposit],
+                                      execution_payload_header: ExecutionPayloadHeader=ExecutionPayloadHeader()
+                                      ) -> BeaconState:
+    fork = Fork(
+        previous_version=CAPELLA_FORK_VERSION,  # [Modified in Capella] for testing only
+        current_version=CAPELLA_FORK_VERSION,  # [Modified in Capella]
+        epoch=GENESIS_EPOCH,
+    )
+    state = BeaconState(
+        genesis_time=eth1_timestamp + GENESIS_DELAY,
+        fork=fork,
+        eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=uint64(len(deposits))),
+        latest_block_header=BeaconBlockHeader(body_root=hash_tree_root(BeaconBlockBody())),
+        randao_mixes=[eth1_block_hash] * EPOCHS_PER_HISTORICAL_VECTOR,  # Seed RANDAO with Eth1 entropy
+    )
+
+    # Process deposits
+    leaves = list(map(lambda deposit: deposit.data, deposits))
+    for index, deposit in enumerate(deposits):
+        deposit_data_list = List[DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH](*leaves[:index + 1])
+        state.eth1_data.deposit_root = hash_tree_root(deposit_data_list)
+        process_deposit(state, deposit)
+
+    # Process activations
+    for index, validator in enumerate(state.validators):
+        balance = state.balances[index]
+        validator.effective_balance = min(balance - balance % EFFECTIVE_BALANCE_INCREMENT, MAX_EFFECTIVE_BALANCE)
+        if validator.effective_balance == MAX_EFFECTIVE_BALANCE:
+            validator.activation_eligibility_epoch = GENESIS_EPOCH
+            validator.activation_epoch = GENESIS_EPOCH
+
+    # Set genesis validators root for domain separation and chain versioning
+    state.genesis_validators_root = hash_tree_root(state.validators)
+
+    # Fill in sync committees
+    # Note: A duplicate committee is assigned for the current and next committee at genesis
+    state.current_sync_committee = get_next_sync_committee(state)
+    state.next_sync_committee = get_next_sync_committee(state)
+
+    # Initialize the execution payload header
+    state.latest_execution_payload_header = execution_payload_header
+
+    return state
+```

--- a/consensus-specs-dev/specs/revoke/fork-choice.md
+++ b/consensus-specs-dev/specs/revoke/fork-choice.md
@@ -1,0 +1,62 @@
+# Capella -- Fork Choice
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Custom types](#custom-types)
+- [Protocols](#protocols)
+  - [`ExecutionEngine`](#executionengine)
+    - [`notify_forkchoice_updated`](#notify_forkchoice_updated)
+- [Helpers](#helpers)
+  - [Extended `PayloadAttributes`](#extended-payloadattributes)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+This is the modification of the fork choice according to the Capella upgrade.
+
+Unless stated explicitly, all prior functionality from [Bellatrix](../bellatrix/fork-choice.md) is inherited.
+
+## Custom types
+
+## Protocols
+
+### `ExecutionEngine`
+
+*Note*: The `notify_forkchoice_updated` function is modified in the `ExecutionEngine` protocol at the Capella upgrade.
+
+#### `notify_forkchoice_updated`
+
+The only change made is to the `PayloadAttributes` container through the addition of `withdrawals`.
+Otherwise, `notify_forkchoice_updated` inherits all prior functionality.
+
+```python
+def notify_forkchoice_updated(self: ExecutionEngine,
+                              head_block_hash: Hash32,
+                              safe_block_hash: Hash32,
+                              finalized_block_hash: Hash32,
+                              payload_attributes: Optional[PayloadAttributes]) -> Optional[PayloadId]:
+    ...
+```
+
+## Helpers
+
+### Extended `PayloadAttributes`
+
+`PayloadAttributes` is extended with the `withdrawals` field.
+
+```python
+@dataclass
+class PayloadAttributes(object):
+    timestamp: uint64
+    prev_randao: Bytes32
+    suggested_fee_recipient: ExecutionAddress
+    withdrawals: Sequence[Withdrawal]  # [New in Capella]
+```

--- a/consensus-specs-dev/specs/revoke/fork.md
+++ b/consensus-specs-dev/specs/revoke/fork.md
@@ -1,0 +1,139 @@
+# Capella -- Fork Logic
+
+## Table of contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Configuration](#configuration)
+- [Helper functions](#helper-functions)
+  - [Misc](#misc)
+    - [Modified `compute_fork_version`](#modified-compute_fork_version)
+- [Fork to Capella](#fork-to-capella)
+  - [Fork trigger](#fork-trigger)
+  - [Upgrading the state](#upgrading-the-state)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Introduction
+
+This document describes the process of the Capella upgrade.
+
+## Configuration
+
+Warning: this configuration is not definitive.
+
+| Name | Value |
+| - | - |
+| `CAPELLA_FORK_VERSION` | `Version('0x03000000')` |
+| `CAPELLA_FORK_EPOCH` | `Epoch(18446744073709551615)` **TBD** |
+
+
+## Helper functions
+
+### Misc
+
+#### Modified `compute_fork_version`
+
+```python
+def compute_fork_version(epoch: Epoch) -> Version:
+    """
+    Return the fork version at the given ``epoch``.
+    """
+    if epoch >= CAPELLA_FORK_EPOCH:
+        return CAPELLA_FORK_VERSION
+    if epoch >= BELLATRIX_FORK_EPOCH:
+        return BELLATRIX_FORK_VERSION
+    if epoch >= ALTAIR_FORK_EPOCH:
+        return ALTAIR_FORK_VERSION
+    return GENESIS_FORK_VERSION
+```
+
+## Fork to Capella
+
+### Fork trigger
+
+The fork is triggered at epoch `CAPELLA_FORK_EPOCH`.
+
+Note that for the pure Capella networks, we don't apply `upgrade_to_capella` since it starts with Capella version logic.
+
+### Upgrading the state
+
+If `state.slot % SLOTS_PER_EPOCH == 0` and `compute_epoch_at_slot(state.slot) == CAPELLA_FORK_EPOCH`,
+an irregular state change is made to upgrade to Capella.
+
+The upgrade occurs after the completion of the inner loop of `process_slots` that sets `state.slot` equal to `CAPELLA_FORK_EPOCH * SLOTS_PER_EPOCH`.
+Care must be taken when transitioning through the fork boundary as implementations will need a modified [state transition function](../phase0/beacon-chain.md#beacon-chain-state-transition-function) that deviates from the Phase 0 document.
+In particular, the outer `state_transition` function defined in the Phase 0 document will not expose the precise fork slot to execute the upgrade in the presence of skipped slots at the fork boundary. Instead, the logic must be within `process_slots`.
+
+```python
+def upgrade_to_capella(pre: bellatrix.BeaconState) -> BeaconState:
+    epoch = bellatrix.get_current_epoch(pre)
+    latest_execution_payload_header = ExecutionPayloadHeader(
+        parent_hash=pre.latest_execution_payload_header.parent_hash,
+        fee_recipient=pre.latest_execution_payload_header.fee_recipient,
+        state_root=pre.latest_execution_payload_header.state_root,
+        receipts_root=pre.latest_execution_payload_header.receipts_root,
+        logs_bloom=pre.latest_execution_payload_header.logs_bloom,
+        prev_randao=pre.latest_execution_payload_header.prev_randao,
+        block_number=pre.latest_execution_payload_header.block_number,
+        gas_limit=pre.latest_execution_payload_header.gas_limit,
+        gas_used=pre.latest_execution_payload_header.gas_used,
+        timestamp=pre.latest_execution_payload_header.timestamp,
+        extra_data=pre.latest_execution_payload_header.extra_data,
+        base_fee_per_gas=pre.latest_execution_payload_header.base_fee_per_gas,
+        block_hash=pre.latest_execution_payload_header.block_hash,
+        transactions_root=pre.latest_execution_payload_header.transactions_root,
+        withdrawals_root=Root(),  # [New in Capella]
+    )
+    post = BeaconState(
+        # Versioning
+        genesis_time=pre.genesis_time,
+        genesis_validators_root=pre.genesis_validators_root,
+        slot=pre.slot,
+        fork=Fork(
+            previous_version=pre.fork.current_version,
+            current_version=CAPELLA_FORK_VERSION,
+            epoch=epoch,
+        ),
+        # History
+        latest_block_header=pre.latest_block_header,
+        block_roots=pre.block_roots,
+        state_roots=pre.state_roots,
+        historical_roots=pre.historical_roots,
+        # Eth1
+        eth1_data=pre.eth1_data,
+        eth1_data_votes=pre.eth1_data_votes,
+        eth1_deposit_index=pre.eth1_deposit_index,
+        # Registry
+        validators=pre.validators,
+        balances=pre.balances,
+        # Randomness
+        randao_mixes=pre.randao_mixes,
+        # Slashings
+        slashings=pre.slashings,
+        # Participation
+        previous_epoch_participation=pre.previous_epoch_participation,
+        current_epoch_participation=pre.current_epoch_participation,
+        # Finality
+        justification_bits=pre.justification_bits,
+        previous_justified_checkpoint=pre.previous_justified_checkpoint,
+        current_justified_checkpoint=pre.current_justified_checkpoint,
+        finalized_checkpoint=pre.finalized_checkpoint,
+        # Inactivity
+        inactivity_scores=pre.inactivity_scores,
+        # Sync
+        current_sync_committee=pre.current_sync_committee,
+        next_sync_committee=pre.next_sync_committee,
+        # Execution-layer
+        latest_execution_payload_header=latest_execution_payload_header,
+        # Withdrawals
+        next_withdrawal_index=WithdrawalIndex(0),  # [New in Capella]
+        next_withdrawal_validator_index=ValidatorIndex(0),  # [New in Capella]
+        # Deep history valid from Capella onwards
+        historical_summaries=List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]([]),  # [New in Capella]
+    )
+
+    return post
+```

--- a/consensus-specs-dev/specs/revoke/light-client/fork.md
+++ b/consensus-specs-dev/specs/revoke/light-client/fork.md
@@ -1,0 +1,92 @@
+# Capella Light Client -- Fork Logic
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+  - [Upgrading light client data](#upgrading-light-client-data)
+  - [Upgrading the store](#upgrading-the-store)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+This document describes how to upgrade existing light client objects based on the [Altair specification](../../altair/light-client/sync-protocol.md) to Capella. This is necessary when processing pre-Capella data with a post-Capella `LightClientStore`. Note that the data being exchanged over the network protocols uses the original format.
+
+### Upgrading light client data
+
+A Capella `LightClientStore` can still process earlier light client data. In order to do so, that pre-Capella data needs to be locally upgraded to Capella before processing.
+
+```python
+def upgrade_lc_header_to_capella(pre: bellatrix.LightClientHeader) -> LightClientHeader:
+    return LightClientHeader(
+        beacon=pre.beacon,
+    )
+```
+
+```python
+def upgrade_lc_bootstrap_to_capella(pre: bellatrix.LightClientBootstrap) -> LightClientBootstrap:
+    return LightClientBootstrap(
+        header=upgrade_lc_header_to_capella(pre.header),
+        current_sync_committee=pre.current_sync_committee,
+        current_sync_committee_branch=pre.current_sync_committee_branch,
+    )
+```
+
+```python
+def upgrade_lc_update_to_capella(pre: bellatrix.LightClientUpdate) -> LightClientUpdate:
+    return LightClientUpdate(
+        attested_header=upgrade_lc_header_to_capella(pre.attested_header),
+        next_sync_committee=pre.next_sync_committee,
+        next_sync_committee_branch=pre.next_sync_committee_branch,
+        finalized_header=upgrade_lc_header_to_capella(pre.finalized_header),
+        finality_branch=pre.finality_branch,
+        sync_aggregate=pre.sync_aggregate,
+        signature_slot=pre.signature_slot,
+    )
+```
+
+```python
+def upgrade_lc_finality_update_to_capella(pre: bellatrix.LightClientFinalityUpdate) -> LightClientFinalityUpdate:
+    return LightClientFinalityUpdate(
+        attested_header=upgrade_lc_header_to_capella(pre.attested_header),
+        finalized_header=upgrade_lc_header_to_capella(pre.finalized_header),
+        finality_branch=pre.finality_branch,
+        sync_aggregate=pre.sync_aggregate,
+        signature_slot=pre.signature_slot,
+    )
+```
+
+```python
+def upgrade_lc_optimistic_update_to_capella(pre: bellatrix.LightClientOptimisticUpdate) -> LightClientOptimisticUpdate:
+    return LightClientOptimisticUpdate(
+        attested_header=upgrade_lc_header_to_capella(pre.attested_header),
+        sync_aggregate=pre.sync_aggregate,
+        signature_slot=pre.signature_slot,
+    )
+```
+
+### Upgrading the store
+
+Existing `LightClientStore` objects based on Altair MUST be upgraded to Capella before Capella based light client data can be processed. The `LightClientStore` upgrade MAY be performed before `CAPELLA_FORK_EPOCH`.
+
+```python
+def upgrade_lc_store_to_capella(pre: bellatrix.LightClientStore) -> LightClientStore:
+    if pre.best_valid_update is None:
+        best_valid_update = None
+    else:
+        best_valid_update = upgrade_lc_update_to_capella(pre.best_valid_update)
+    return LightClientStore(
+        finalized_header=upgrade_lc_header_to_capella(pre.finalized_header),
+        current_sync_committee=pre.current_sync_committee,
+        next_sync_committee=pre.next_sync_committee,
+        best_valid_update=best_valid_update,
+        optimistic_header=upgrade_lc_header_to_capella(pre.optimistic_header),
+        previous_max_active_participants=pre.previous_max_active_participants,
+        current_max_active_participants=pre.current_max_active_participants,
+    )
+```

--- a/consensus-specs-dev/specs/revoke/light-client/full-node.md
+++ b/consensus-specs-dev/specs/revoke/light-client/full-node.md
@@ -1,0 +1,78 @@
+# Capella Light Client -- Full Node
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Helper functions](#helper-functions)
+  - [`compute_merkle_proof_for_block_body`](#compute_merkle_proof_for_block_body)
+  - [Modified `block_to_light_client_header`](#modified-block_to_light_client_header)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+This upgrade adds information about the execution payload to light client data as part of the Capella upgrade.
+
+## Helper functions
+
+### `compute_merkle_proof_for_block_body`
+
+```python
+def compute_merkle_proof_for_block_body(body: BeaconBlockBody,
+                                        index: GeneralizedIndex) -> Sequence[Bytes32]:
+    ...
+```
+
+### Modified `block_to_light_client_header`
+
+```python
+def block_to_light_client_header(block: SignedBeaconBlock) -> LightClientHeader:
+    epoch = compute_epoch_at_slot(block.message.slot)
+
+    if epoch >= CAPELLA_FORK_EPOCH:
+        payload = block.message.body.execution_payload
+        execution_header = ExecutionPayloadHeader(
+            parent_hash=payload.parent_hash,
+            fee_recipient=payload.fee_recipient,
+            state_root=payload.state_root,
+            receipts_root=payload.receipts_root,
+            logs_bloom=payload.logs_bloom,
+            prev_randao=payload.prev_randao,
+            block_number=payload.block_number,
+            gas_limit=payload.gas_limit,
+            gas_used=payload.gas_used,
+            timestamp=payload.timestamp,
+            extra_data=payload.extra_data,
+            base_fee_per_gas=payload.base_fee_per_gas,
+            block_hash=payload.block_hash,
+            transactions_root=hash_tree_root(payload.transactions),
+            withdrawals_root=hash_tree_root(payload.withdrawals),
+        )
+        execution_branch = compute_merkle_proof_for_block_body(block.message.body, EXECUTION_PAYLOAD_INDEX)
+    else:
+        # Note that during fork transitions, `finalized_header` may still point to earlier forks.
+        # While Bellatrix blocks also contain an `ExecutionPayload` (minus `withdrawals_root`),
+        # it was not included in the corresponding light client data. To ensure compatibility
+        # with legacy data going through `upgrade_lc_header_to_capella`, leave out execution data.
+        execution_header = ExecutionPayloadHeader()
+        execution_branch = [Bytes32() for _ in range(floorlog2(EXECUTION_PAYLOAD_INDEX))]
+
+    return LightClientHeader(
+        beacon=BeaconBlockHeader(
+            slot=block.message.slot,
+            proposer_index=block.message.proposer_index,
+            parent_root=block.message.parent_root,
+            state_root=block.message.state_root,
+            body_root=hash_tree_root(block.message.body),
+        ),
+        execution=execution_header,
+        execution_branch=execution_branch,
+    )
+```

--- a/consensus-specs-dev/specs/revoke/light-client/p2p-interface.md
+++ b/consensus-specs-dev/specs/revoke/light-client/p2p-interface.md
@@ -1,0 +1,99 @@
+# Capella Light Client -- Networking
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Networking](#networking)
+  - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
+    - [Topics and messages](#topics-and-messages)
+      - [Global topics](#global-topics)
+        - [`light_client_finality_update`](#light_client_finality_update)
+        - [`light_client_optimistic_update`](#light_client_optimistic_update)
+  - [The Req/Resp domain](#the-reqresp-domain)
+    - [Messages](#messages)
+      - [GetLightClientBootstrap](#getlightclientbootstrap)
+      - [LightClientUpdatesByRange](#lightclientupdatesbyrange)
+      - [GetLightClientFinalityUpdate](#getlightclientfinalityupdate)
+      - [GetLightClientOptimisticUpdate](#getlightclientoptimisticupdate)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Networking
+
+The [Altair light client networking specification](../../altair/light-client/p2p-interface.md) is extended to exchange [Capella light client data](./sync-protocol.md).
+
+### The gossip domain: gossipsub
+
+#### Topics and messages
+
+##### Global topics
+
+###### `light_client_finality_update`
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`                                         | Message SSZ type                      |
+| ------------------------------------------------------ | ------------------------------------- |
+| `GENESIS_FORK_VERSION`                                 | n/a                                   |
+| `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientFinalityUpdate`    |
+| `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientFinalityUpdate`   |
+
+###### `light_client_optimistic_update`
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`                                         | Message SSZ type                      |
+| ------------------------------------------------------ | ------------------------------------- |
+| `GENESIS_FORK_VERSION`                                 | n/a                                   |
+| `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientOptimisticUpdate`  |
+| `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientOptimisticUpdate` |
+
+### The Req/Resp domain
+
+#### Messages
+
+##### GetLightClientBootstrap
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`                                         | Response SSZ type                     |
+| ------------------------------------------------------ | ------------------------------------- |
+| `GENESIS_FORK_VERSION`                                 | n/a                                   |
+| `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientBootstrap`         |
+| `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientBootstrap`        |
+
+##### LightClientUpdatesByRange
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`                                         | Response chunk SSZ type               |
+| ------------------------------------------------------ | ------------------------------------- |
+| `GENESIS_FORK_VERSION`                                 | n/a                                   |
+| `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientUpdate`            |
+| `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientUpdate`           |
+
+##### GetLightClientFinalityUpdate
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`                                         | Response SSZ type                     |
+| ------------------------------------------------------ | ------------------------------------- |
+| `GENESIS_FORK_VERSION`                                 | n/a                                   |
+| `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientFinalityUpdate`    |
+| `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientFinalityUpdate`   |
+
+##### GetLightClientOptimisticUpdate
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`                                         | Response SSZ type                     |
+| ------------------------------------------------------ | ------------------------------------- |
+| `GENESIS_FORK_VERSION`                                 | n/a                                   |
+| `ALTAIR_FORK_VERSION` through `BELLATRIX_FORK_VERSION` | `altair.LightClientOptimisticUpdate`  |
+| `CAPELLA_FORK_VERSION` and later                       | `capella.LightClientOptimisticUpdate` |

--- a/consensus-specs-dev/specs/revoke/p2p-interface.md
+++ b/consensus-specs-dev/specs/revoke/p2p-interface.md
@@ -1,0 +1,112 @@
+# Capella -- Networking
+
+This document contains the networking specification for Capella.
+
+The specification of these changes continues in the same format as the network specifications of previous upgrades, and assumes them as pre-requisite.
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Modifications in Capella](#modifications-in-capella)
+  - [The gossip domain: gossipsub](#the-gossip-domain-gossipsub)
+    - [Topics and messages](#topics-and-messages)
+      - [Global topics](#global-topics)
+        - [`beacon_block`](#beacon_block)
+        - [`bls_to_execution_change`](#bls_to_execution_change)
+    - [Transitioning the gossip](#transitioning-the-gossip)
+  - [The Req/Resp domain](#the-reqresp-domain)
+    - [Messages](#messages)
+      - [BeaconBlocksByRange v2](#beaconblocksbyrange-v2)
+      - [BeaconBlocksByRoot v2](#beaconblocksbyroot-v2)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+
+# Modifications in Capella
+
+## The gossip domain: gossipsub
+
+A new topic is added to support the gossip of withdrawal credential change messages. And an existing topic is upgraded for updated types in Capella.
+
+### Topics and messages
+
+Topics follow the same specification as in prior upgrades. All existing topics remain stable except the beacon block topic which is updated with the modified type.
+
+The new topics along with the type of the `data` field of a gossipsub message are given in this table:
+
+| Name | Message Type |
+| - | - |
+| `beacon_block` | `SignedBeaconBlock` (modified) |
+| `bls_to_execution_change` | `SignedBLSToExecutionChange` |
+
+Note that the `ForkDigestValue` path segment of the topic separates the old and the new `beacon_block` topics.
+
+#### Global topics
+
+Capella changes the type of the global beacon block topic and adds one global topic to propagate withdrawal credential change messages to all potential proposers of beacon blocks.
+
+##### `beacon_block`
+
+The *type* of the payload of this topic changes to the (modified) `SignedBeaconBlock` found in Capella.
+Specifically, this type changes with the addition of `bls_to_execution_changes` to the inner `BeaconBlockBody`.
+See Capella [state transition document](./beacon-chain.md#beaconblockbody) for further details.
+
+##### `bls_to_execution_change`
+
+This topic is used to propagate signed bls to execution change messages to be included in future blocks.
+
+The following validations MUST pass before forwarding the `signed_bls_to_execution_change` on the network:
+
+- _[IGNORE]_ `current_epoch >= CAPELLA_FORK_EPOCH`,
+  where `current_epoch` is defined by the current wall-clock time.
+- _[IGNORE]_ The `signed_bls_to_execution_change` is the first valid signed bls to execution change received
+  for the validator with index `signed_bls_to_execution_change.message.validator_index`.
+- _[REJECT]_ All of the conditions within `process_bls_to_execution_change` pass validation.
+
+### Transitioning the gossip
+
+See gossip transition details found in the [Altair document](../altair/p2p-interface.md#transitioning-the-gossip) for
+details on how to handle transitioning gossip topics for Capella.
+
+## The Req/Resp domain
+
+### Messages
+
+#### BeaconBlocksByRange v2
+
+**Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_range/2/`
+
+The Capella fork-digest is introduced to the `context` enum to specify Capella block type.
+
+Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
+
+[0]: # (eth2spec: skip)
+
+| `fork_version`           | Chunk SSZ type             |
+| ------------------------ | -------------------------- |
+| `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock` |
+| `ALTAIR_FORK_VERSION`    | `altair.SignedBeaconBlock` |
+| `BELLATRIX_FORK_VERSION` | `bellatrix.SignedBeaconBlock` |
+| `CAPELLA_FORK_VERSION`   | `capella.SignedBeaconBlock` |
+
+#### BeaconBlocksByRoot v2
+
+**Protocol ID:** `/eth2/beacon_chain/req/beacon_blocks_by_root/2/`
+
+The Capella fork-digest is introduced to the `context` enum to specify Capella block type.
+
+Per `context = compute_fork_digest(fork_version, genesis_validators_root)`:
+
+[1]: # (eth2spec: skip)
+
+| `fork_version`           | Chunk SSZ type             |
+| ------------------------ | -------------------------- |
+| `GENESIS_FORK_VERSION`   | `phase0.SignedBeaconBlock` |
+| `ALTAIR_FORK_VERSION`    | `altair.SignedBeaconBlock` |
+| `BELLATRIX_FORK_VERSION` | `bellatrix.SignedBeaconBlock` |
+| `CAPELLA_FORK_VERSION`   | `capella.SignedBeaconBlock` |
+

--- a/consensus-specs-dev/specs/revoke/validator.md
+++ b/consensus-specs-dev/specs/revoke/validator.md
@@ -1,0 +1,147 @@
+# Capella -- Honest Validator
+
+**Notice**: This document is a work-in-progress for researchers and implementers.
+
+## Table of contents
+
+<!-- TOC -->
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Helpers](#helpers)
+- [Protocols](#protocols)
+  - [`ExecutionEngine`](#executionengine)
+    - [`get_payload`](#get_payload)
+- [Beacon chain responsibilities](#beacon-chain-responsibilities)
+  - [Block proposal](#block-proposal)
+    - [Constructing the `BeaconBlockBody`](#constructing-the-beaconblockbody)
+      - [ExecutionPayload](#executionpayload)
+      - [BLS to execution changes](#bls-to-execution-changes)
+- [Enabling validator withdrawals](#enabling-validator-withdrawals)
+  - [Changing from BLS to execution withdrawal credentials](#changing-from-bls-to-execution-withdrawal-credentials)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+<!-- /TOC -->
+
+## Introduction
+
+This document represents the changes to be made in the code of an "honest validator" to implement the Capella upgrade.
+
+## Prerequisites
+
+This document is an extension of the [Bellatrix -- Honest Validator](../bellatrix/validator.md) guide.
+All behaviors and definitions defined in this document, and documents it extends, carry over unless explicitly noted or overridden.
+
+All terminology, constants, functions, and protocol mechanics defined in the updated Beacon Chain doc of [Capella](./beacon-chain.md) are requisite for this document and used throughout.
+Please see related Beacon Chain doc before continuing and use them as a reference throughout.
+
+## Helpers
+
+## Protocols
+
+### `ExecutionEngine`
+
+#### `get_payload`
+
+`get_payload` returns the upgraded Capella `ExecutionPayload` type.
+
+## Beacon chain responsibilities
+
+All validator responsibilities remain unchanged other than those noted below.
+
+### Block proposal
+
+#### Constructing the `BeaconBlockBody`
+
+##### ExecutionPayload
+
+`ExecutionPayload`s are constructed as they were in Bellatrix, except that the
+expected withdrawals for the slot must be gathered from the `state` (utilizing the
+helper `get_expected_withdrawals`) and passed into the `ExecutionEngine` within `prepare_execution_payload`.
+
+*Note*: In this section, `state` is the state of the slot for the block proposal _without_ the block yet applied.
+That is, `state` is the `previous_state` processed through any empty slots up to the assigned slot using `process_slots(previous_state, slot)`.
+
+*Note*: The only change made to `prepare_execution_payload` is to call
+`get_expected_withdrawals()` to set the new `withdrawals` field of `PayloadAttributes`.
+
+```python
+def prepare_execution_payload(state: BeaconState,
+                              pow_chain: Dict[Hash32, PowBlock],
+                              safe_block_hash: Hash32,
+                              finalized_block_hash: Hash32,
+                              suggested_fee_recipient: ExecutionAddress,
+                              execution_engine: ExecutionEngine) -> Optional[PayloadId]:
+    if not is_merge_transition_complete(state):
+        is_terminal_block_hash_set = TERMINAL_BLOCK_HASH != Hash32()
+        is_activation_epoch_reached = get_current_epoch(state) >= TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH
+        if is_terminal_block_hash_set and not is_activation_epoch_reached:
+            # Terminal block hash is set but activation epoch is not yet reached, no prepare payload call is needed
+            return None
+
+        terminal_pow_block = get_terminal_pow_block(pow_chain)
+        if terminal_pow_block is None:
+            # Pre-merge, no prepare payload call is needed
+            return None
+        # Signify merge via producing on top of the terminal PoW block
+        parent_hash = terminal_pow_block.block_hash
+    else:
+        # Post-merge, normal payload
+        parent_hash = state.latest_execution_payload_header.block_hash
+
+    # Set the forkchoice head and initiate the payload build process
+    payload_attributes = PayloadAttributes(
+        timestamp=compute_timestamp_at_slot(state, state.slot),
+        prev_randao=get_randao_mix(state, get_current_epoch(state)),
+        suggested_fee_recipient=suggested_fee_recipient,
+        withdrawals=get_expected_withdrawals(state),  # [New in Capella]
+    )
+    return execution_engine.notify_forkchoice_updated(
+        head_block_hash=parent_hash,
+        safe_block_hash=safe_block_hash,
+        finalized_block_hash=finalized_block_hash,
+        payload_attributes=payload_attributes,
+    )
+```
+
+##### BLS to execution changes
+
+Up to `MAX_BLS_TO_EXECUTION_CHANGES`, [`BLSToExecutionChange`](./beacon-chain.md#blstoexecutionchange) objects can be included in the `block`. The BLS to execution changes must satisfy the verification conditions found in [BLS to execution change processing](./beacon-chain.md#new-process_bls_to_execution_change).
+
+## Enabling validator withdrawals
+
+Validator balances are withdrawn periodically via an automatic process. For exited validators, the full balance is withdrawn. For active validators, the balance in excess of `MAX_EFFECTIVE_BALANCE` is withdrawn.
+
+There is one prerequisite for this automated process:
+the validator's withdrawal credentials pointing to an execution layer address, i.e. having an `ETH1_ADDRESS_WITHDRAWAL_PREFIX`.
+
+If a validator has a `BLS_WITHDRAWAL_PREFIX` withdrawal credential prefix, to participate in withdrawals the validator must 
+create a one-time message to change their withdrawal credential from the version authenticated with a BLS key to the
+version compatible with the execution layer. This message -- a `BLSToExecutionChange` -- is available starting in Capella
+
+Validators who wish to enable withdrawals **MUST** assemble, sign, and broadcast this message so that it is accepted
+on the beacon chain. Validators who do not want to enable withdrawals and have the `BLS_WITHDRAWAL_PREFIX` version of
+withdrawal credentials can delay creating this message until they are ready to enable withdrawals.
+
+### Changing from BLS to execution withdrawal credentials
+
+First, the validator must construct a valid [`BLSToExecutionChange`](./beacon-chain.md#blstoexecutionchange) `message`.
+This `message` contains the `validator_index` for the validator who wishes to change their credentials, the `from_bls_pubkey` -- the BLS public key corresponding to the **withdrawal BLS secret key** used to form the `BLS_WITHDRAWAL_PREFIX` withdrawal credential, and the `to_execution_address` specifying the execution layer address to which the validator's balances will be withdrawn.
+
+*Note*: The withdrawal key pair used to construct the `BLS_WITHDRAWAL_PREFIX` withdrawal credential should be distinct from the signing key pair used to operate the validator under typical circumstances. Consult your validator deposit tooling documentation for further details if you are not aware of the difference.
+
+*Warning*: This message can only be included on-chain once and is
+irreversible so ensure the correctness and accessibility to `to_execution_address`.
+
+Next, the validator signs the assembled `message: BLSToExecutionChange` with the **withdrawal BLS secret key** and this
+`signature` is placed into a `SignedBLSToExecutionChange` message along with the inner `BLSToExecutionChange` `message`.
+Note that the `SignedBLSToExecutionChange` message should pass all of the validations in [`process_bls_to_execution_change`](./beacon-chain.md#new-process_bls_to_execution_change).
+
+The `SignedBLSToExecutionChange` message should then be submitted to the consensus layer network. Once included on-chain,
+the withdrawal credential change takes effect. No further action is required for a validator to enter into the automated
+withdrawal process.
+
+*Note*: A node *should* prioritize locally received `BLSToExecutionChange` operations to ensure these changes make it on-chain
+through self published blocks even if the rest of the network censors.

--- a/consensus-specs-dev/tests/core/pyspec/eth2spec/test/revoke/block_processing/test_process_pubkey_change.py
+++ b/consensus-specs-dev/tests/core/pyspec/eth2spec/test/revoke/block_processing/test_process_pubkey_change.py
@@ -1,0 +1,183 @@
+from eth2spec.test.helpers.keys import pubkeys, privkeys, pubkey_to_privkey
+from eth2spec.test.helpers.pubkey_changes import get_signed_pubkey_change
+
+from eth2spec.test.context import spec_state_test, expect_assertion_error, with_revoke_and_later, always_bls
+
+def run_pubkey_change_processing(spec, state, signed_pubkey_change, valid=True):
+    """
+    Run ``process_pubkey_change``, yielding:
+      - pre-state ('pre')
+      - pubkey-change ('pubkey_change')
+      - post-state ('post').
+    If ``valid == False``, run expecting ``AssertionError``
+    """
+    # yield pre-state - this will store some values to check later that certain updates happended.
+    yield 'pre', state
+
+    yield 'pubkey_change', signed_pubkey_change
+
+    # If the pubkey_change is invalid, processing is aborted, and there is no post-state.
+    if not valid:
+        expect_assertion_error(lambda: spec.process_pubkey_change(state, signed_pubkey_change))
+        yield 'post', None
+        return
+
+    # process pubkey change
+    spec.process_pubkey_change(state, signed_pubkey_change)
+
+    # Make sure the address change has been processed
+    validator_index = signed_pubkey_change.message.validator_index
+    validator = state.validators[validator_index]
+    
+    assert validator.new_pubkey == signed_pubkey_change.message.new_pubkey
+    assert validator.pubkey_change_epoch == signed_pubkey_change.message.epoch  
+
+    # yield post-state
+    yield 'post', state
+
+
+##### The below are the test cases for bls to execution change processing
+
+@with_revoke_and_later
+@spec_state_test
+def test_success(spec, state):
+    signed_pubkey_change = get_signed_pubkey_change(spec, state)
+    yield from run_pubkey_change_processing(spec, state, signed_pubkey_change)
+
+"""
+@with_capella_and_later
+@spec_state_test
+def test_success(spec, state):
+    signed_address_change = get_signed_address_change(spec, state)
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+
+@with_capella_and_later
+@spec_state_test
+def test_success_not_activated(spec, state):
+    validator_index = 3
+    validator = state.validators[validator_index]
+    validator.activation_eligibility_epoch += 4
+    validator.activation_epoch = spec.FAR_FUTURE_EPOCH
+
+    assert not spec.is_active_validator(validator, spec.get_current_epoch(state))
+
+    signed_address_change = get_signed_address_change(spec, state)
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+    validator = state.validators[validator_index]
+    balance = state.balances[validator_index]
+    assert not spec.is_fully_withdrawable_validator(validator, balance, spec.get_current_epoch(state))
+
+
+@with_capella_and_later
+@spec_state_test
+def test_success_in_activation_queue(spec, state):
+    validator_index = 3
+    validator = state.validators[validator_index]
+    validator.activation_eligibility_epoch = spec.get_current_epoch(state)
+    validator.activation_epoch += 4
+
+    assert not spec.is_active_validator(validator, spec.get_current_epoch(state))
+
+    signed_address_change = get_signed_address_change(spec, state)
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+    validator = state.validators[validator_index]
+    balance = state.balances[validator_index]
+    assert not spec.is_fully_withdrawable_validator(validator, balance, spec.get_current_epoch(state))
+
+
+@with_capella_and_later
+@spec_state_test
+def test_success_in_exit_queue(spec, state):
+    validator_index = 3
+    spec.initiate_validator_exit(state, validator_index)
+
+    assert spec.is_active_validator(state.validators[validator_index], spec.get_current_epoch(state))
+    assert spec.get_current_epoch(state) < state.validators[validator_index].exit_epoch
+
+    signed_address_change = get_signed_address_change(spec, state, validator_index=validator_index)
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+
+@with_capella_and_later
+@spec_state_test
+def test_success_exited(spec, state):
+    validator_index = 4
+    validator = state.validators[validator_index]
+    validator.exit_epoch = spec.get_current_epoch(state)
+
+    assert not spec.is_active_validator(validator, spec.get_current_epoch(state))
+
+    signed_address_change = get_signed_address_change(spec, state, validator_index=validator_index)
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+    validator = state.validators[validator_index]
+    balance = state.balances[validator_index]
+    assert not spec.is_fully_withdrawable_validator(validator, balance, spec.get_current_epoch(state))
+
+
+@with_capella_and_later
+@spec_state_test
+def test_success_withdrawable(spec, state):
+    validator_index = 4
+    validator = state.validators[validator_index]
+    validator.exit_epoch = spec.get_current_epoch(state)
+    validator.withdrawable_epoch = spec.get_current_epoch(state)
+
+    assert not spec.is_active_validator(validator, spec.get_current_epoch(state))
+
+    signed_address_change = get_signed_address_change(spec, state, validator_index=validator_index)
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change)
+
+    validator = state.validators[validator_index]
+    balance = state.balances[validator_index]
+    assert spec.is_fully_withdrawable_validator(validator, balance, spec.get_current_epoch(state))
+
+
+@with_capella_and_later
+@spec_state_test
+def test_fail_val_index_out_of_range(spec, state):
+    # Create for one validator beyond the validator list length
+    signed_address_change = get_signed_address_change(spec, state, validator_index=len(state.validators))
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
+
+
+@with_capella_and_later
+@spec_state_test
+def test_fail_already_0x01(spec, state):
+    # Create for one validator beyond the validator list length
+    validator_index = len(state.validators) // 2
+    validator = state.validators[validator_index]
+    validator.withdrawal_credentials = b'\x01' + b'\x00' * 11 + b'\x23' * 20
+    signed_address_change = get_signed_address_change(spec, state, validator_index=validator_index)
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
+
+
+@with_capella_and_later
+@spec_state_test
+def test_fail_incorrect_from_bls_pubkey(spec, state):
+    # Create for one validator beyond the validator list length
+    validator_index = 2
+    signed_address_change = get_signed_address_change(
+        spec, state,
+        validator_index=validator_index,
+        withdrawal_pubkey=pubkeys[0],
+    )
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
+
+
+@with_capella_and_later
+@spec_state_test
+@always_bls
+def test_fail_bad_signature(spec, state):
+    signed_address_change = get_signed_address_change(spec, state)
+    # Mutate signature
+    signed_address_change.signature = spec.BLSSignature(b'\x42' * 96)
+
+    yield from run_bls_to_execution_change_processing(spec, state, signed_address_change, valid=False)
+"""


### PR DESCRIPTION
This update contains implementation of the pubkey-change (revoke) feature. the base: main is the latest upstream version of the pyspec. All new implementations have been added to a new branch 'consensus-specs-dev-revoke. 

Currently not able to generate executable for revoke since there is an error: ValueError: 'KZGCommitment' is not in list
make: *** [Makefile:101: pyspec] Error 1

A new test case is also added in the revoke/block_processing/test_process_pubkey_change.py

Initially all the changes were implemented directly into the revoke/mainnet.py and the new test "test_process_pubkey_change" was successful. 